### PR TITLE
+ relop_project()

### DIFF
--- a/duckdb-rfuns-r/DESCRIPTION
+++ b/duckdb-rfuns-r/DESCRIPTION
@@ -21,4 +21,5 @@ Imports:
     duckdb,
     tibble,
     withr,
-    DBI
+    DBI,
+    rlang

--- a/duckdb-rfuns-r/R/relop.R
+++ b/duckdb-rfuns-r/R/relop.R
@@ -1,0 +1,33 @@
+relop_project <- function(x, y, op = c("<", "<=", ">", ">=", "==", "!=")) {
+  op <- rlang::arg_match(op)
+  fun <- glue::glue("r_base::{op}")
+
+  experimental <- FALSE
+  con <- duckdbrfuns:::con()
+  withr::defer(dbDisconnect(con, shutdown=TRUE))
+
+  df1 <- data.frame(a = x, b = y)
+
+
+  rel1 <- duckdb$rel_from_df(con, df1, experimental = experimental)
+  duckdb$rel_project(
+    rel1,
+    list(
+      {
+        tmp_expr <- duckdb$expr_reference("a")
+        duckdb$expr_set_alias(tmp_expr, "a")
+        tmp_expr
+      },
+      {
+        tmp_expr <- duckdb$expr_reference("b")
+        duckdb$expr_set_alias(tmp_expr, "b")
+        tmp_expr
+      },
+      {
+        tmp_expr <- duckdb$expr_function(fun, list(duckdb$expr_reference("a"), duckdb$expr_reference("b")))
+        duckdb$expr_set_alias(tmp_expr, "a < b")
+        tmp_expr
+      }
+    )
+  )
+}

--- a/duckdb-rfuns-r/R/zzz.R
+++ b/duckdb-rfuns-r/R/zzz.R
@@ -5,3 +5,5 @@
 #' @importFrom withr defer_parent
 #' @importFrom DBI dbConnect dbDisconnect dbGetQuery
 NULL
+
+duckdb <- asNamespace("duckdb")


### PR DESCRIPTION
Adding internal `relop_project()` function to make it easier to test things:

``` r
duckdbrfuns:::relop_project(1, 2)
#> DuckDB Relation: 
#> ---------------------
#> --- Relation Tree ---
#> ---------------------
#> Projection [a as a, b as b, r_base::<(a, b) as a < b]
#>   r_dataframe_scan(0x1202908c8)
#> 
#> ---------------------
#> -- Result Columns  --
#> ---------------------
#> - a (DOUBLE)
#> - b (DOUBLE)
#> - a < b (BOOLEAN)
duckdbrfuns:::relop_project(Sys.Date(), Sys.time())
#> DuckDB Relation: 
#> ---------------------
#> --- Relation Tree ---
#> ---------------------
#> Projection [a as a, b as b, r_base::<(a, b) as a < b]
#>   r_dataframe_scan(0x1076f4fc8)
#> 
#> ---------------------
#> -- Result Columns  --
#> ---------------------
#> - a (DATE)
#> - b (TIMESTAMP)
#> - a < b (BOOLEAN)
```

<sup>Created on 2024-03-07 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>