### PR TITLE
poc for relop_dispatch()

### DIFF
--- a/duckdb-rfuns-r/R/relop.R
+++ b/duckdb-rfuns-r/R/relop.R
@@ -1,4 +1,4 @@
-relop_project <- function(x, y, op = c("<", "<=", ">", ">=", "==", "!="), error_call = current_env(), con = local_duckdb_con()) {
+relop_project <- function(x, y, op = c("<", "<=", ">", ">=", "==", "!=", "<=>"), error_call = current_env(), con = local_duckdb_con()) {
   op <- arg_match(op, error_call = error_call)
   fun <- glue("r_base::{op}")
   alias <- glue("a {op} b")
@@ -29,14 +29,20 @@ relop_project <- function(x, y, op = c("<", "<=", ">", ">=", "==", "!="), error_
   )
 }
 
-relop_altrep <- function(x, y, op = c("<", "<=", ">", ">=", "==", "!="), error_call = current_env(), con = auto_duckdb_con()) {
-  project <- relop_project(x, y, op, error_call = error_call, con = con)
+relop_altrep <- function(x, y, op = c("<", "<=", ">", ">=", "==", "!=", "<=>"), error_call = current_env(), con = auto_duckdb_con()) {
+  project <- relop_project(x, y, op = op, error_call = error_call, con = con)
   df <- duckdb$rel_to_altrep(project)
   attr(df, "con") <- con
   df
 }
 
-relop_sql <- function(x, y, op = c("<", "<=", ">", ">=", "==", "!="), error_call = current_env(), con = local_duckdb_con()) {
-  project <- relop_project(x, y, op, error_call = error_call, con = con)
+relop_sql <- function(x, y, op = c("<", "<=", ">", ">=", "==", "!=", "<=>"), error_call = current_env(), con = local_duckdb_con()) {
+  project <- relop_project(x, y, op = op, error_call = error_call, con = con)
   duckdb$rel_to_sql(project)
+}
+
+relop_dispatch <- function(x, y) {
+  project <- relop_project(x, y, op = "<=>", error_call = current_env(), con = local_duckdb_con())
+  result <- try(duckdb$rel_to_altrep(project)[1, 3], silent = TRUE)
+  invisible(NULL)
 }

--- a/src/include/rfuns_extension.hpp
+++ b/src/include/rfuns_extension.hpp
@@ -30,6 +30,7 @@ ScalarFunctionSet base_r_lt();
 ScalarFunctionSet base_r_lte();
 ScalarFunctionSet base_r_gt();
 ScalarFunctionSet base_r_gte();
+ScalarFunctionSet base_r_relop_dispatch();
 
 } // namespace rfuns
 

--- a/src/rfuns_extension.cpp
+++ b/src/rfuns_extension.cpp
@@ -31,6 +31,9 @@ static void LoadInternal(DatabaseInstance &instance) {
 	ExtensionUtil::RegisterFunction(instance, rfuns::base_r_gt());
 	ExtensionUtil::RegisterFunction(instance, rfuns::base_r_gte());
 
+	// relop_dispatch
+	ExtensionUtil::RegisterFunction(instance, rfuns::base_r_relop_dispatch());
+
 	// Register a scalar function
 	auto rfuns_scalar_function = ScalarFunction("rfuns", {LogicalType::VARCHAR}, LogicalType::VARCHAR, RfunsScalarFun);
 	ExtensionUtil::RegisterFunction(instance, rfuns_scalar_function);


### PR DESCRIPTION
This is a quick and dirty hack to find out which variant is selected, i.e. : 

```r
> duckdbrfuns:::relop_dispatch(1, 2)
DOUBLE + DOUBLE
> duckdbrfuns:::relop_dispatch(1L, 2)
INTEGER + DOUBLE
> duckdbrfuns:::relop_dispatch(1, 2L)
DOUBLE + INTEGER
> 
> duckdbrfuns:::relop_dispatch(Sys.Date(), Sys.Date())
VARCHAR + VARCHAR
> duckdbrfuns:::relop_dispatch(Sys.time(), Sys.time())
VARCHAR + VARCHAR
> duckdbrfuns:::relop_dispatch("hello", Sys.time())
VARCHAR + VARCHAR
```

I think `base_r_relop_dispatch`  should instead bd generated, but perhaps we should figure out how to leverage `FunctionBinder::BindFunctionsFromArguments()`. 

