### PR TITLE
feat: Tweak implementation of `r_base::sum()`

### DIFF
--- a/.github/workflows/ClientTests.yml
+++ b/.github/workflows/ClientTests.yml
@@ -23,6 +23,6 @@ concurrency:
 jobs:
   client-tests:
     name: Client Tests
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_client_tests.yml@v1.0.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_client_tests.yml@v1.1.0
     with:
-      duckdb_version: v1.0.0
+      duckdb_version: v1.1.0

--- a/.github/workflows/R-check.yaml
+++ b/.github/workflows/R-check.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout DuckDB to version
         run: |
           cd duckdb
-          git checkout v1.0.0
+          git checkout v1.1.0
 
       - name: build duckdb extension
         run: make

--- a/.github/workflows/_extension_distribution_0.10.2.yml
+++ b/.github/workflows/_extension_distribution_0.10.2.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           make test
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |
@@ -259,7 +259,7 @@ jobs:
         run: |
           make test
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |
@@ -333,7 +333,7 @@ jobs:
         run: |
           make test
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |
@@ -386,7 +386,7 @@ jobs:
         run: |
           make ${{ matrix.duckdb_arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |

--- a/duckdb-rfuns-r/DESCRIPTION
+++ b/duckdb-rfuns-r/DESCRIPTION
@@ -25,4 +25,4 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/duckdb-rfuns-r/tests/testthat/_snaps/sum.md
+++ b/duckdb-rfuns-r/tests/testthat/_snaps/sum.md
@@ -6,7 +6,7 @@
       Error in `rfuns_sum()`:
       ! binding error
       Caused by error:
-      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(BOOLEAN, VARCHAR)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER) -> INTEGER\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> INTEGER,r_base::sum(INTEGER) -> INTEGER,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(BOOLEAN, VARCHAR)","error_subtype":"NO_MATCHING_FUNCTION"}
+      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(BOOLEAN, VARCHAR)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> DOUBLE\n\tr_base::sum(INTEGER) -> DOUBLE\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> DOUBLE,r_base::sum(INTEGER) -> DOUBLE,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(BOOLEAN, VARCHAR)","error_subtype":"NO_MATCHING_FUNCTION"}
 
 ---
 
@@ -16,7 +16,7 @@
       Error in `rfuns_sum()`:
       ! binding error
       Caused by error:
-      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(INTEGER, VARCHAR)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER) -> INTEGER\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> INTEGER,r_base::sum(INTEGER) -> INTEGER,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(INTEGER, VARCHAR)","error_subtype":"NO_MATCHING_FUNCTION"}
+      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(INTEGER, VARCHAR)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> DOUBLE\n\tr_base::sum(INTEGER) -> DOUBLE\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> DOUBLE,r_base::sum(INTEGER) -> DOUBLE,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(INTEGER, VARCHAR)","error_subtype":"NO_MATCHING_FUNCTION"}
 
 ---
 
@@ -26,7 +26,7 @@
       Error in `rfuns_sum()`:
       ! binding error
       Caused by error:
-      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(DOUBLE, VARCHAR)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER) -> INTEGER\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> INTEGER,r_base::sum(INTEGER) -> INTEGER,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(DOUBLE, VARCHAR)","error_subtype":"NO_MATCHING_FUNCTION"}
+      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(DOUBLE, VARCHAR)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> DOUBLE\n\tr_base::sum(INTEGER) -> DOUBLE\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> DOUBLE,r_base::sum(INTEGER) -> DOUBLE,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(DOUBLE, VARCHAR)","error_subtype":"NO_MATCHING_FUNCTION"}
 
 # r_base::sum(<VARCHAR>
 
@@ -36,7 +36,7 @@
       Error in `rfuns_sum()`:
       ! binding error
       Caused by error:
-      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(VARCHAR)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER) -> INTEGER\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> INTEGER,r_base::sum(INTEGER) -> INTEGER,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(VARCHAR)","error_subtype":"NO_MATCHING_FUNCTION"}
+      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(VARCHAR)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> DOUBLE\n\tr_base::sum(INTEGER) -> DOUBLE\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> DOUBLE,r_base::sum(INTEGER) -> DOUBLE,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(VARCHAR)","error_subtype":"NO_MATCHING_FUNCTION"}
 
 ---
 
@@ -46,7 +46,7 @@
       Error in `rfuns_sum()`:
       ! binding error
       Caused by error:
-      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(VARCHAR, BOOLEAN)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER) -> INTEGER\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> INTEGER,r_base::sum(INTEGER) -> INTEGER,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(VARCHAR, BOOLEAN)","error_subtype":"NO_MATCHING_FUNCTION"}
+      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(VARCHAR, BOOLEAN)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> DOUBLE\n\tr_base::sum(INTEGER) -> DOUBLE\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> DOUBLE,r_base::sum(INTEGER) -> DOUBLE,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(VARCHAR, BOOLEAN)","error_subtype":"NO_MATCHING_FUNCTION"}
 
 ---
 
@@ -56,5 +56,5 @@
       Error in `rfuns_sum()`:
       ! binding error
       Caused by error:
-      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(VARCHAR, BOOLEAN)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER) -> INTEGER\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> INTEGER,r_base::sum(INTEGER) -> INTEGER,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(VARCHAR, BOOLEAN)","error_subtype":"NO_MATCHING_FUNCTION"}
+      ! {"exception_type":"Binder","exception_message":"No function matches the given name and argument types 'r_base::sum(VARCHAR, BOOLEAN)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tr_base::sum(BOOLEAN, BOOLEAN) -> INTEGER\n\tr_base::sum(BOOLEAN) -> INTEGER\n\tr_base::sum(INTEGER, BOOLEAN) -> DOUBLE\n\tr_base::sum(INTEGER) -> DOUBLE\n\tr_base::sum(DOUBLE, BOOLEAN) -> DOUBLE\n\tr_base::sum(DOUBLE) -> DOUBLE\n","name":"r_base::sum","candidates":"r_base::sum(BOOLEAN, BOOLEAN) -> INTEGER,r_base::sum(BOOLEAN) -> INTEGER,r_base::sum(INTEGER, BOOLEAN) -> DOUBLE,r_base::sum(INTEGER) -> DOUBLE,r_base::sum(DOUBLE, BOOLEAN) -> DOUBLE,r_base::sum(DOUBLE) -> DOUBLE","call":"r_base::sum(VARCHAR, BOOLEAN)","error_subtype":"NO_MATCHING_FUNCTION"}
 

--- a/duckdb-rfuns-r/tests/testthat/test-sum.R
+++ b/duckdb-rfuns-r/tests/testthat/test-sum.R
@@ -28,6 +28,13 @@ test_that("r_base::sum(<INTEGER>)", {
   expect_equal(rfuns_sum(empty), sum(empty))
 })
 
+test_that("r_base::sum(<INTEGER>) -> dbl", {
+  x <- 1:10
+  expect_true(is.double(rfuns_sum(x, na.rm = TRUE)))
+  expect_true(is.double(rfuns_sum(x, na.rm = FALSE)))
+  expect_true(is.double(rfuns_sum(x)))
+})
+
 test_that("r_base::sum(<DOUBLE>)", {
   x <- c(1, 2, 3, NA)
   empty <- double()

--- a/src/is_na.cpp
+++ b/src/is_na.cpp
@@ -17,9 +17,9 @@ void isna_double_loop(idx_t count, const double* data, bool* result_data, Validi
 		idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
 
 		if (ValidityMask::AllValid(validity_entry)) {
-			// all valid: check with isnan()
+			// all valid: check with std::isnan()
 			for (; base_idx < next; base_idx++) {
-				result_data[base_idx] = isnan(data[base_idx]);
+				result_data[base_idx] = std::isnan(data[base_idx]);
 			}
 		} else if (ValidityMask::NoneValid(validity_entry)) {
 			// None valid:
@@ -32,7 +32,7 @@ void isna_double_loop(idx_t count, const double* data, bool* result_data, Validi
 			for (; base_idx < next; base_idx++) {
 				if (ValidityMask::RowIsValid(validity_entry, base_idx - start)) {
 					D_ASSERT(mask.RowIsValid(base_idx));
-					result_data[base_idx] = isnan(data[base_idx]);
+					result_data[base_idx] = std::isnan(data[base_idx]);
 				} else {
 					result_data[base_idx] = true;
 				}
@@ -64,7 +64,7 @@ void isna_double(DataChunk &args, ExpressionState &state, Vector &result) {
 			auto result_data = ConstantVector::GetData<bool>(result);
 			auto ldata = ConstantVector::GetData<double>(input);
 
-			*result_data = ConstantVector::IsNull(input) || isnan(*ldata);
+			*result_data = ConstantVector::IsNull(input) || std::isnan(*ldata);
 
 			break;
 		}
@@ -101,7 +101,7 @@ void isna_any_loop(idx_t count, bool* result_data, ValidityMask mask) {
 		idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
 
 		if (ValidityMask::AllValid(validity_entry)) {
-			// all valid: check with isnan()
+			// all valid: check with std::isnan()
 			for (; base_idx < next; base_idx++) {
 				result_data[base_idx] = false;
 			}

--- a/src/is_na.cpp
+++ b/src/is_na.cpp
@@ -101,7 +101,7 @@ void isna_any_loop(idx_t count, bool* result_data, ValidityMask mask) {
 		idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
 
 		if (ValidityMask::AllValid(validity_entry)) {
-			// all valid: check with std::isnan()
+			// all valid
 			for (; base_idx < next; base_idx++) {
 				result_data[base_idx] = false;
 			}

--- a/src/sum.cpp
+++ b/src/sum.cpp
@@ -22,6 +22,7 @@ struct RSumOperation {
 
 	template <class STATE>
 	static void Initialize(STATE &state) {
+		state.value = 0;
 		state.is_set = false;
 		state.is_null = false;
 	}
@@ -81,10 +82,10 @@ unique_ptr<FunctionData> BindRSum_dispatch(ClientContext &context, AggregateFunc
 		function = AggregateFunction::UnaryAggregate<RSumKeepNaState<double>, double, double, RSumOperation<RegularAdd, NA_RM>>(type, type);
 		break;
 	case LogicalTypeId::INTEGER:
-		function = AggregateFunction::UnaryAggregate<RSumKeepNaState<hugeint_t>, int32_t, hugeint_t, RSumOperation<HugeintAdd, NA_RM>>(type, type);
+		function = AggregateFunction::UnaryAggregate<RSumKeepNaState<double>, int32_t, double, RSumOperation<RegularAdd, NA_RM>>(type, LogicalTypeId::DOUBLE);
 		break;
 	case LogicalTypeId::BOOLEAN:
-		function = AggregateFunction::UnaryAggregate<RSumKeepNaState<int32_t>, bool, int32_t, RSumOperation<RegularAdd, NA_RM>>(LogicalType::BOOLEAN, LogicalType::INTEGER);
+		function = AggregateFunction::UnaryAggregate<RSumKeepNaState<int32_t>, bool, int32_t, RSumOperation<RegularAdd, NA_RM>>(type, LogicalType::INTEGER);
 		break;
 	default:
 		break;
@@ -102,8 +103,7 @@ unique_ptr<FunctionData> BindRSum(ClientContext &context, AggregateFunction &fun
 	}
 }
 
-void add_RSum(AggregateFunctionSet& set, const LogicalType& type) {
-	auto return_type = type == LogicalType::BOOLEAN ? LogicalType::INTEGER : type;
+void add_RSum(AggregateFunctionSet& set, const LogicalType& type, const LogicalType& return_type) {
 	set.AddFunction(AggregateFunction(
 		{type, LogicalType::BOOLEAN}, return_type,
 		nullptr, nullptr, nullptr, nullptr, nullptr, FunctionNullHandling::DEFAULT_NULL_HANDLING, nullptr,
@@ -120,9 +120,9 @@ void add_RSum(AggregateFunctionSet& set, const LogicalType& type) {
 AggregateFunctionSet base_r_sum() {
 	AggregateFunctionSet set("r_base::sum");
 
-	add_RSum(set, LogicalType::BOOLEAN);
-	add_RSum(set, LogicalType::INTEGER);
-	add_RSum(set, LogicalType::DOUBLE);
+	add_RSum(set, LogicalType::BOOLEAN, LogicalType::INTEGER);
+	add_RSum(set, LogicalType::INTEGER, LogicalType::DOUBLE);
+	add_RSum(set, LogicalType::DOUBLE, LogicalType::DOUBLE);
 
 	return set;
 }


### PR DESCRIPTION
- We must be type stable because `sum()` upcasts to doubles only with overflow, we _always_ upcast to doubles
- I saw something that looked like uninitialized memory in one of my tests
- What's the best way to update the tests here?

Also closes #100.